### PR TITLE
Fix command state and level references for Anniversary Update

### DIFF
--- a/src/accessors/CommandConsole.cs
+++ b/src/accessors/CommandConsole.cs
@@ -1,12 +1,23 @@
-using System;
-using System.Collections.Generic;
 using HarmonyLib;
+using System;
+using System.Collections;
+using System.Reflection;
 
 namespace MoreCommands.Accessors;
 
 public static class CommandConsoleAccessor
 {
-    public static readonly AccessTools.FieldRef<CommandConsole, Dictionary<string, CommandConsole.Command>> commandsRef = AccessTools.FieldRefAccess<CommandConsole, Dictionary<string, CommandConsole.Command>>("commands");
+    public static IDictionary GetCommands(CommandConsole instance)
+    {
+        FieldInfo commandsField = AccessTools.Field(typeof(CommandConsole), "states");
+
+        object commandStackInstance = commandsField.GetValue(instance);
+        object currentState = commandsField.FieldType.GetMethod("Peek").Invoke(commandStackInstance, null);
+
+        FieldInfo commands = AccessTools.Field(AccessTools.Inner(typeof(CommandConsole), "CommandLineState"), "commands");
+
+        return (IDictionary)commands.GetValue(currentState);
+    }
 
     private static readonly Action<CommandConsole, string[]> EnableCheatsRaw =
     AccessTools.MethodDelegate<Action<CommandConsole, string[]>>(

--- a/src/commands/LoadRegions.cs
+++ b/src/commands/LoadRegions.cs
@@ -20,7 +20,7 @@ public sealed class LoadRegionCommand : CommandBase
             if ((regions?.Count() ?? 0) == 0) return;
             try
             {
-                string[] levels = regions.Data().SelectMany(x => x.GetLevels(null)).Select(x => x.name.ToLower()).ToArray();
+                string[] levels = regions.Data().SelectMany(x => x.GetLevels(null)).Select(x => x.level.levelName.ToLower()).ToArray();
                 if (levels.Length == 0)
                 {
                     Accessors.CommandConsoleAccessor.EchoToConsole($"Failed to generate levels for regions:\n- {regions.Join()}");

--- a/src/commands/LoadSubregions.cs
+++ b/src/commands/LoadSubregions.cs
@@ -18,7 +18,7 @@ public sealed class LoadSubregionCommand : CommandBase
         {
             Handle<M_Subregion> subregions = Prefabs.SubregionProvider().FromCommandMany(args);
             if ((subregions?.Count() ?? 0) == 0) return;
-            string[] levels = subregions.Data().SelectMany(x => x.levels).Select(x => x.name.ToLower()).ToArray();
+            string[] levels = subregions.Data().SelectMany(x => x.levelReferences).Select(x => x.level.name.ToLower()).ToArray();
             if (levels.Length == 0)
             {
                 Accessors.CommandConsoleAccessor.EchoToConsole($"Failed to get levels for subregions:\n- {subregions.Join()}");

--- a/src/patches/CommandConsole.cs
+++ b/src/patches/CommandConsole.cs
@@ -60,7 +60,7 @@ public static class CommandConsole_RegisterCommand_Patcher
     {
         // base game registers chains commands and I don't want that behavior
         if (command == null || CommandConsole.instance == null || __instance == null) return false;
-        var commandsDict = Accessors.CommandConsoleAccessor.commandsRef(CommandConsole.instance);
-        return !commandsDict.ContainsKey(command);
+        var commandsDict = Accessors.CommandConsoleAccessor.GetCommands(CommandConsole.instance);
+        return !commandsDict.Contains(command);
     }
 }

--- a/src/prefabs/Levels.cs
+++ b/src/prefabs/Levels.cs
@@ -14,8 +14,8 @@ public class Levels : HandleProvider<M_Level>
 
     public void Initialize()
     {
-        _levels = CL_AssetManager.GetFullCombinedAssetDatabase().levelPrefabs
-            .Select(obj => obj.GetComponent<M_Level>())
+        _levels = CL_AssetManager.GetFullCombinedAssetDatabase().levelAssets
+            .Select(x => x.level)
             .Where(c => c != null)
             .Distinct()
             .ToList()

--- a/src/prefabs/Subregions.cs
+++ b/src/prefabs/Subregions.cs
@@ -12,7 +12,7 @@ public class Subregions : HandleProvider<M_Subregion>
     public void Initialize()
     {
         _subregions = CL_AssetManager.GetFullCombinedAssetDatabase().subRegionAssets
-            .Where(x => x != null && (x.levels?.Count ?? 0) > 0)
+            .Where(x => x != null && (x.levelReferences?.Count ?? 0) > 0)
             .Distinct()
             .ToList()
         ;


### PR DESCRIPTION
Updates the commands reference to use the new command stack state:
- Updated to get the command state stack and peek the top for the current instance of commands
  - Since the update there were internal changes made to WK's CommandConsole:
    - Commands contain a new stack that stores the current state which returns the current list of commands
    - Command object is no longer public
- Changed level and region references to updated variable names